### PR TITLE
DATA-9955 ParquetWriter to Overwrite

### DIFF
--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-benchmarks/pom.xml
+++ b/parquet-benchmarks/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-cascading/pom.xml
+++ b/parquet-cascading/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-column/pom.xml
+++ b/parquet-column/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-common/pom.xml
+++ b/parquet-common/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-encoding/pom.xml
+++ b/parquet-encoding/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-generator/pom.xml
+++ b/parquet-generator/pom.xml
@@ -49,6 +49,18 @@
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
+      <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-remote-resources-plugin</artifactId>
+            <version>1.5</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-filtering</artifactId>
+                <version>1.2</version>
+              </dependency>
+            </dependencies>
+       </plugin>
     </plugins>
   </build>
 </project>

--- a/parquet-generator/pom.xml
+++ b/parquet-generator/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hadoop-bundle/pom.xml
+++ b/parquet-hadoop-bundle/pom.xml
@@ -21,7 +21,8 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <!-- custom version to be accessed from lyft-hive repo for Sonata  -->
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -310,7 +310,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
 
     WriteContext init = writeSupport.init(conf);
     ParquetFileWriter w = new ParquetFileWriter(
-        conf, init.getSchema(), file, Mode.CREATE, blockSize, maxPaddingSize);
+        conf, init.getSchema(), file, Mode.OVERWRITE, blockSize, maxPaddingSize);
     w.start();
 
     float maxLoad = conf.getFloat(ParquetOutputFormat.MEMORY_POOL_RATIO,

--- a/parquet-hive-bundle/pom.xml
+++ b/parquet-hive-bundle/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hive/parquet-hive-binding/parquet-hive-0.10-binding/pom.xml
+++ b/parquet-hive/parquet-hive-binding/parquet-hive-0.10-binding/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet-hive-binding</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hive/parquet-hive-binding/parquet-hive-0.12-binding/pom.xml
+++ b/parquet-hive/parquet-hive-binding/parquet-hive-0.12-binding/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet-hive-binding</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hive/parquet-hive-binding/parquet-hive-binding-bundle/pom.xml
+++ b/parquet-hive/parquet-hive-binding/parquet-hive-binding-bundle/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet-hive-binding</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hive/parquet-hive-binding/parquet-hive-binding-factory/pom.xml
+++ b/parquet-hive/parquet-hive-binding/parquet-hive-binding-factory/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet-hive-binding</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hive/parquet-hive-binding/parquet-hive-binding-interface/pom.xml
+++ b/parquet-hive/parquet-hive-binding/parquet-hive-binding-interface/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet-hive-binding</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hive/parquet-hive-binding/pom.xml
+++ b/parquet-hive/parquet-hive-binding/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet-hive</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hive/parquet-hive-storage-handler/pom.xml
+++ b/parquet-hive/parquet-hive-storage-handler/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet-hive</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-hive/pom.xml
+++ b/parquet-hive/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-jackson/pom.xml
+++ b/parquet-jackson/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-pig-bundle/pom.xml
+++ b/parquet-pig-bundle/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-pig/pom.xml
+++ b/parquet-pig/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-scala/pom.xml
+++ b/parquet-scala/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/parquet-tools/pom.xml
+++ b/parquet-tools/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.8.1</version>
+    <version>1.8.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.apache.parquet</groupId>
   <artifactId>parquet</artifactId>
-  <version>1.8.1</version>
+  <version>1.8.1.1</version>
   <packaging>pom</packaging>
 
   <name>Apache Parquet MR</name>


### PR DESCRIPTION
Open Source ParquetWriter hardcodes the mode to CREATE. We need to be able to overwrite the files in case of task re-attempts with S3 as backend system.

- Bumped up the version to `1.8.1.1` to create a custom jar with this change